### PR TITLE
Remove image letterboxing (extent + background)

### DIFF
--- a/core/app/models/spree/image.rb
+++ b/core/app/models/spree/image.rb
@@ -18,8 +18,6 @@ module Spree
           url: polymorphic_path(attachment.variant(
                                   gravity: 'center',
                                   resize: size,
-                                  extent: size,
-                                  background: 'snow2',
                                   quality: 80
                                 ), only_path: true),
           width: width,
@@ -38,8 +36,6 @@ module Spree
         url: polymorphic_path(attachment.variant(
                                 gravity: 'center',
                                 resize: size,
-                                extent: size,
-                                background: 'snow2',
                                 quality: 80
                               ), only_path: true),
         size: size,
@@ -63,8 +59,6 @@ module Spree
       variant = attachment.variant(
         gravity: 'center',
         resize: size,
-        extent: size,
-        background: 'snow2',
         quality: 80
       )
 


### PR DESCRIPTION
## Summary
- Removed `extent: size` and `background: 'snow2'` from all image variant methods (`styles`, `style`, `plp_url`)
- Images now keep their natural aspect ratio after resize instead of being padded to exact square dimensions with an off-white background
- Frontend uses CSS `object-fit: cover` to fill containers, so no visual change needed downstream

## Before
Images resized to fit within e.g. 600x600, then **padded** to exactly 600x600 with `snow2` (off-white) background — creating visible letterboxing on dark-themed storefronts.

## After  
Images resized to fit within max dimensions, keeping natural aspect ratio. No padding, no background fill.

## Note
Existing cached ActiveStorage variants in S3 will still have the old letterboxing until they expire or are purged.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)